### PR TITLE
checkin tab click animation too slow and sometimes breaks the script

### DIFF
--- a/southwest_checkin.py
+++ b/southwest_checkin.py
@@ -36,6 +36,9 @@ while not checkin.is_displayed():
 	print 
 checkin.click()
 
+# checkin click is animated and can be too slow so wait a second
+sleep(1)
+
 # get text boxes for check in
 confirmation_num = driver.find_element_by_id("confirmationNumber")
 first_name = driver.find_element_by_id("firstName")


### PR DESCRIPTION
The checkin tab click is animated an sometimes the animation is too slow for the following driver.find_element_id calls to get a handle on the checkin text boxes. added a 1 second wait just after checkin tab click to make it more reliable. Tested it and got A group!